### PR TITLE
To Production - v1.2.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,37 @@
 services:
   server:
     container_name: falacomigo-container
+    restart: always
+    
+    networks:
+      - proxy-public
+      - default 
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.fala.rule=Host(`server.falacomigo.space`)"
+      - "traefik.http.routers.fala.entrypoints=websecure"
+      - "traefik.http.routers.fala.tls.certresolver=myresolver" 
+      - "traefik.http.services.fala.loadbalancer.server.port=8080"
+
     build:
       context: .
       dockerfile: Dockerfile
       args:
         DATABASE_URL: ${DATABASE_URL}
-    restart: always
-    ports:
-      - "8080:8080"
     environment:
-        NODE_ENV: production
-        DATABASE_URL: ${DATABASE_URL}
-        REDIS_HOST: ${REDIS_HOST}
-        JWT_SECRET: ${JWT_SECRET}
-        GROQ_API_KEY: ${GROQ_API_KEY}
-        REDIS_URL: ${REDIS_URL}
-        REDIS_PORT: 6379
-        PORT: 8080
-        REDIS_PASSWORD: ${REDIS_PASSWORD}
+      NODE_ENV: production
+      PORT: 8080
+      DATABASE_URL: ${DATABASE_URL}
+      REDIS_HOST: ${REDIS_HOST}
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      REDIS_URL: ${REDIS_URL}
+      JWT_SECRET: ${JWT_SECRET}
+      GROQ_API_KEY: ${GROQ_API_KEY}
+
     command: ["npm", "start"]
+
+
+networks:
+  proxy-public:
+    external: true


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` configuration to improve deployment and networking for the `server` service. The main changes include integrating Traefik for reverse proxy and SSL, adjusting environment variable handling, and updating network settings.

**Traefik Integration and Networking:**

* Added Traefik labels to the `server` service for routing, SSL termination, and automatic certificate management, and connected the service to the `proxy-public` network for reverse proxy support.
* Removed the direct port mapping (`ports`) in favor of Traefik-managed routing.
* Declared an external `proxy-public` network to enable Traefik integration.

**Environment Variable and Service Configuration:**

* Cleaned up and reordered environment variables for clarity and completeness, ensuring all necessary variables are set for production.
* Moved the `restart: always` directive for better organization and reliability.