### PR TITLE
Handle empty translatedText on message translation

### DIFF
--- a/src/ai-tools/ai-tools.service.ts
+++ b/src/ai-tools/ai-tools.service.ts
@@ -67,6 +67,9 @@ export class AiToolsService {
       );
     }
 
+    aiResponse.translation.translatedText ??=
+      'Não há tradução disponível para esta mensagem.';
+
     await this.profile.update(senderId, {
       tokensBalance: profileData.tokensBalance - 1,
     });


### PR DESCRIPTION
## Description
This PR fixes an issue where message updates could fail when the translation service returns `null` for `translatedText`.

This scenario happens when a user tries to translate a message that is already in their native language.

## Problem
- `translatedText` is a required field in the database.
- Prisma throws an error when attempting to update records with a null value.
- The error interrupts an otherwise valid user action.

## Solution
A default fallback text is now assigned whenever `translatedText` is null, ensuring database consistency and preventing update failures.

Closes #59 
