### PR TITLE
To production - v1.2.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 services:
-
   redis:
     image: redis:alpine
     container_name: redis-fc-container
@@ -7,6 +6,7 @@ services:
     command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}
     volumes:
       - ./data:/data
+
   server:
     container_name: falacomigo-container
     restart: always
@@ -21,7 +21,7 @@ services:
       - "traefik.http.routers.fala.entrypoints=websecure"
       - "traefik.http.routers.fala.tls.certresolver=myresolver" 
       - "traefik.http.services.fala.loadbalancer.server.port=8080"
-
+      - "traefik.docker.network=proxy-public" 
     build:
       context: .
       dockerfile: Dockerfile
@@ -41,8 +41,30 @@ services:
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
 
     command: ["npm", "start"]
-
+  traefik:
+    image: traefik:v3.6
+    container_name: traefik
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.myresolver.acme.httpchallenge=true"
+      - "--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web"
+      - "--certificatesresolvers.myresolver.acme.email=${LETSENCRYPT_EMAIL}"
+      - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "./letsencrypt:/letsencrypt" 
+    networks:
+      - proxy-public
 
 networks:
   proxy-public:
-    external: true
+    driver: bridge


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file to improve service orchestration and add support for Traefik as a reverse proxy with automatic HTTPS. The main changes include introducing a Traefik service, updating network configurations, and enhancing service labels for better proxy integration.

**Traefik reverse proxy integration:**
* Added a new `traefik` service configured as a reverse proxy, including automatic HTTPS with Let's Encrypt and Docker provider support. This includes exposed ports 80 and 443, volume mounts for Docker socket and certificate storage, and detailed command-line arguments for Traefik configuration.

**Network and service configuration improvements:**
* Changed the `proxy-public` network from external to a local bridge network for easier local development and isolation.
* Added the `traefik.docker.network=proxy-public` label to the `server` service to ensure proper network routing by Traefik.

**Service definition cleanup:**
* Reorganized the `server` and `redis` service definitions for clarity and maintainability.